### PR TITLE
Add Nix dev shell and centralize dependency config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,9 @@ graph TD
 - **Workspace-level dependencies**: All dependencies are managed in the
   workspace root `deno.jsonc`. Individual package `deno.json` files should not
   contain `imports` or `scopes`.
+  - **Exception**: `@probitas/cli` intentionally contains its own `imports`
+    because it programmatically reads them to inject dependencies into
+    subprocesses.
 - **JSR protocol for internal deps**: Use `jsr:@probitas/xxx@^0` for
   inter-package dependencies (workspace root provides path overrides for
   development)

--- a/deno.lock
+++ b/deno.lock
@@ -149,12 +149,6 @@
       "jsr:@std/testing@^1.0.16"
     ],
     "members": {
-      "packages/probitas-builder": {
-        "dependencies": [
-          "jsr:@probitas/runner@0",
-          "jsr:@probitas/scenario@0"
-        ]
-      },
       "packages/probitas-cli": {
         "dependencies": [
           "jsr:@core/errorutil@^1.2.1",
@@ -172,22 +166,6 @@
           "jsr:@std/jsonc@^1.0.2",
           "jsr:@std/path@^1.1.3",
           "jsr:@std/streams@^1.0.14"
-        ]
-      },
-      "packages/probitas-reporter": {
-        "dependencies": [
-          "jsr:@probitas/runner@0",
-          "jsr:@probitas/scenario@0"
-        ]
-      },
-      "packages/probitas-runner": {
-        "dependencies": [
-          "jsr:@probitas/scenario@0"
-        ]
-      },
-      "packages/probitas-std": {
-        "dependencies": [
-          "jsr:@probitas/builder@0"
         ]
       }
     }

--- a/packages/probitas-builder/deno.json
+++ b/packages/probitas-builder/deno.json
@@ -7,9 +7,5 @@
       "**/*_test.ts",
       "**/*_bench.ts"
     ]
-  },
-  "imports": {
-    "@probitas/scenario": "jsr:@probitas/scenario@^0",
-    "@probitas/runner": "jsr:@probitas/runner@^0"
   }
 }

--- a/packages/probitas-reporter/deno.json
+++ b/packages/probitas-reporter/deno.json
@@ -7,9 +7,5 @@
       "**/*_test.ts",
       "**/*_bench.ts"
     ]
-  },
-  "imports": {
-    "@probitas/scenario": "jsr:@probitas/scenario@^0",
-    "@probitas/runner": "jsr:@probitas/runner@^0"
   }
 }

--- a/packages/probitas-runner/deno.json
+++ b/packages/probitas-runner/deno.json
@@ -7,8 +7,5 @@
       "**/*_test.ts",
       "**/*_bench.ts"
     ]
-  },
-  "imports": {
-    "@probitas/scenario": "jsr:@probitas/scenario@^0"
   }
 }

--- a/packages/probitas-std/deno.json
+++ b/packages/probitas-std/deno.json
@@ -7,8 +7,5 @@
       "**/*_test.ts",
       "**/*_bench.ts"
     ]
-  },
-  "imports": {
-    "@probitas/builder": "jsr:@probitas/builder@^0"
   }
 }


### PR DESCRIPTION
## Summary
- add repo guidelines in CLAUDE.md and document Nix-based dev workflow in README
- provide a verify task for fmt/lint/check/test and remove per-package imports to rely on workspace config
- introduce Nix flake/lock for a consistent Deno toolchain

## Testing
- deno task verify