### PR TITLE
Add reload flag forwarding to run and list commands

### DIFF
--- a/packages/probitas-cli/assets/usage-list.txt
+++ b/packages/probitas-cli/assets/usage-list.txt
@@ -14,6 +14,7 @@ Options:
                              Supports ! prefix for negation
   --json                     Output in JSON format
   --config <path>            Path to config file (deno.json/deno.jsonc)
+  -r, --reload               Reload dependencies before running
 
 Selector Format:
   [!][type:]value
@@ -63,5 +64,6 @@ Examples:
 
   # JSON output
   probitas list --json                          Output as JSON
+  probitas list --reload                        Reload dependencies before listing
 
 Note: Uses patterns from config file or defaults to "**/*.scenario.ts"

--- a/packages/probitas-cli/assets/usage-run.txt
+++ b/packages/probitas-cli/assets/usage-run.txt
@@ -19,6 +19,7 @@ Options:
   --max-failures <n>        Stop after N failures
   -f, --fail-fast           Stop on first failure (alias for --max-failures=1)
   --config <path>           Path to config file (deno.json/deno.jsonc)
+  -r, --reload              Reload dependencies before running
   -q, --quiet               Quiet output (errors only)
   -v, --verbose             Verbose output
   -d, --debug               Debug output (maximum detail)
@@ -78,6 +79,7 @@ Examples:
   probitas run --sequential                 Run scenarios sequentially
   probitas run --max-failures 1             Stop on first failure
   probitas run -f                           Stop on first failure (alias)
+  probitas run --reload                     Reload dependencies before running
 
   # Output control
   probitas run -v                           Verbose output

--- a/packages/probitas-cli/commands/_test_utils.ts
+++ b/packages/probitas-cli/commands/_test_utils.ts
@@ -1,0 +1,53 @@
+/**
+ * Test helpers for command-level tests.
+ */
+
+type CaptureFn = (args: string[]) => void;
+
+const defaultStatus: Deno.CommandStatus = {
+  success: true,
+  code: 0,
+  signal: null,
+};
+
+/**
+ * Stub `Deno.Command` and capture args passed to the constructor.
+ *
+ * Restores the original value on dispose.
+ *
+ * @param capture - Function invoked with the args passed to Deno.Command
+ * @returns Disposable handle to restore the original Command
+ */
+export function stubDenoCommand(
+  capture: CaptureFn,
+  status: Deno.CommandStatus = defaultStatus,
+): Disposable {
+  const originalCommand = Deno.Command;
+
+  class StubbedCommand {
+    constructor(_cmd: string, options: Deno.CommandOptions) {
+      capture(options.args ?? []);
+    }
+
+    spawn() {
+      return {
+        stdin: {
+          getWriter: () => ({
+            async write(_data: Uint8Array) {},
+            async close() {},
+          }),
+        },
+        status: Promise.resolve(status),
+      };
+    }
+  }
+
+  (Deno as { Command: typeof Deno.Command }).Command =
+    StubbedCommand as unknown as typeof Deno.Command;
+
+  return {
+    [Symbol.dispose]() {
+      (Deno as { Command: typeof Deno.Command }).Command = originalCommand;
+    },
+  };
+}

--- a/packages/probitas-cli/commands/list.ts
+++ b/packages/probitas-cli/commands/list.ts
@@ -32,11 +32,12 @@ export async function listCommand(
     // Parse command-line arguments
     const parsed = parseArgs(args, {
       string: ["config", "include", "exclude", "selector"],
-      boolean: ["help", "json"],
+      boolean: ["help", "json", "reload"],
       collect: ["include", "exclude", "selector"],
       alias: {
         h: "help",
         s: "selector",
+        r: "reload",
       },
       default: {
         include: undefined,
@@ -110,6 +111,7 @@ export async function listCommand(
       "-A", // All permissions
       "--config",
       subprocessConfigPath,
+      ...(parsed.reload ? ["--reload"] : []),
       subprocessPath,
     ];
 

--- a/packages/probitas-cli/commands/run.ts
+++ b/packages/probitas-cli/commands/run.ts
@@ -44,6 +44,7 @@ export async function runCommand(
       boolean: [
         "help",
         "no-color",
+        "reload",
         "quiet",
         "verbose",
         "debug",
@@ -59,6 +60,7 @@ export async function runCommand(
         v: "verbose",
         q: "quiet",
         d: "debug",
+        r: "reload",
       },
       default: {
         include: undefined,
@@ -166,6 +168,7 @@ export async function runCommand(
       "-A", // All permissions
       "--config",
       subprocessConfigPath,
+      ...(parsed.reload ? ["--reload"] : []),
       subprocessPath,
     ];
 


### PR DESCRIPTION
- Add -r/--reload option to probitas run and probitas list and forward --reload to subprocess
- Document reload option in CLI usage text
- Add test helper for stubbing Deno.Command and cover reload forwarding