### PR TITLE
chore: release 2025.12.08

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,103 @@
 ### 2025.12.08
 
+#### @probitas/builder 0.2.6 (patch)
+
+- docs(*): Document new Runner and Reporter architecture
+- refactor(*): Refactor and Refine reporters
+- refactor(*): Refactor and Refine scenario runner
+- refactor(*): Transform resource/setup step to common step
+- refactor(*): Fix option values in definitions
+- refactor(*): Rename factory to fn
+- refactor(*): Use complex types only in builder
+- refactor(*): Make options optional
+- refactor(*): Rename SourceLocation to Source
+
+#### @probitas/cli 0.3.4 (patch)
+
+- docs(*): Document new Runner and Reporter architecture
+- refactor(*): Refactor and Refine reporters
+- refactor(*): Refactor and Refine scenario runner
+- refactor(*): Transform resource/setup step to common step
+- refactor(*): Fix option values in definitions
+- refactor(*): Rename factory to fn
+- refactor(*): Use complex types only in builder
+- refactor(*): Make options optional
+- refactor(*): Rename SourceLocation to Source
+
+#### @probitas/discover 0.2.6 (patch)
+
+- docs(*): Document new Runner and Reporter architecture
+- refactor(*): Refactor and Refine reporters
+- refactor(*): Refactor and Refine scenario runner
+- refactor(*): Transform resource/setup step to common step
+- refactor(*): Fix option values in definitions
+- refactor(*): Rename factory to fn
+- refactor(*): Use complex types only in builder
+- refactor(*): Make options optional
+- refactor(*): Rename SourceLocation to Source
+
+#### @probitas/logger 0.2.6 (patch)
+
+- docs(*): Document new Runner and Reporter architecture
+- refactor(*): Refactor and Refine reporters
+- refactor(*): Refactor and Refine scenario runner
+- refactor(*): Transform resource/setup step to common step
+- refactor(*): Fix option values in definitions
+- refactor(*): Rename factory to fn
+- refactor(*): Use complex types only in builder
+- refactor(*): Make options optional
+- refactor(*): Rename SourceLocation to Source
+
+#### @probitas/probitas 0.3.5 (patch)
+
+- docs(*): Document new Runner and Reporter architecture
+- refactor(*): Refactor and Refine reporters
+- refactor(*): Refactor and Refine scenario runner
+- refactor(*): Transform resource/setup step to common step
+- refactor(*): Fix option values in definitions
+- refactor(*): Rename factory to fn
+- refactor(*): Use complex types only in builder
+- refactor(*): Make options optional
+- refactor(*): Rename SourceLocation to Source
+
+#### @probitas/reporter 0.2.6 (patch)
+
+- docs(*): Document new Runner and Reporter architecture
+- refactor(*): Refactor and Refine reporters
+- refactor(*): Refactor and Refine scenario runner
+- refactor(*): Transform resource/setup step to common step
+- refactor(*): Fix option values in definitions
+- refactor(*): Rename factory to fn
+- refactor(*): Use complex types only in builder
+- refactor(*): Make options optional
+- refactor(*): Rename SourceLocation to Source
+
+#### @probitas/runner 0.2.6 (patch)
+
+- docs(*): Document new Runner and Reporter architecture
+- refactor(*): Refactor and Refine reporters
+- refactor(*): Refactor and Refine scenario runner
+- refactor(*): Transform resource/setup step to common step
+- refactor(*): Fix option values in definitions
+- refactor(*): Rename factory to fn
+- refactor(*): Use complex types only in builder
+- refactor(*): Make options optional
+- refactor(*): Rename SourceLocation to Source
+
+#### @probitas/scenario 0.2.6 (patch)
+
+- docs(*): Document new Runner and Reporter architecture
+- refactor(*): Refactor and Refine reporters
+- refactor(*): Refactor and Refine scenario runner
+- refactor(*): Transform resource/setup step to common step
+- refactor(*): Fix option values in definitions
+- refactor(*): Rename factory to fn
+- refactor(*): Use complex types only in builder
+- refactor(*): Make options optional
+- refactor(*): Rename SourceLocation to Source
+
+### 2025.12.08
+
 #### @probitas/builder 0.2.5 (patch)
 
 - docs(*): add Publish badge and reorganize packages table

--- a/packages/probitas-builder/deno.json
+++ b/packages/probitas-builder/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/builder",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-cli/deno.json
+++ b/packages/probitas-cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-discover/deno.json
+++ b/packages/probitas-discover/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/discover",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-logger/deno.json
+++ b/packages/probitas-logger/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/logger",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-reporter/deno.json
+++ b/packages/probitas-reporter/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/reporter",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-runner/deno.json
+++ b/packages/probitas-runner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/runner",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-scenario/deno.json
+++ b/packages/probitas-scenario/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/scenario",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas/deno.json
+++ b/packages/probitas/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/probitas",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "exports": {
     ".": "./mod.ts",
     "./expect": "./expect.ts",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@probitas/builder|0.2.5|0.2.6|patch|
|@probitas/cli|0.3.3|0.3.4|patch|
|@probitas/discover|0.2.5|0.2.6|patch|
|@probitas/logger|0.2.5|0.2.6|patch|
|@probitas/probitas|0.3.4|0.3.5|patch|
|@probitas/reporter|0.2.5|0.2.6|patch|
|@probitas/runner|0.2.5|0.2.6|patch|
|@probitas/scenario|0.2.5|0.2.6|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly

The following commits are not recognized. Please handle them manually if necessary:

- [Merge pull request #21 from jsr-probitas/ref](/jsr-probitas/probitas/commit/3d5626a4f92c8fb5d715780c0c27214dc95d41fa)
- [deps(*): Upgrade dependencies](/jsr-probitas/probitas/commit/39385ce1b0d223fe2b27545f4227b6228f714887)

The following commits have unknown scopes. Please handle them manually if necessary:

- [refactor(probitas-scenario): Rearrangel types directory structure](/jsr-probitas/probitas/commit/b794b21be2f7a899ce09a6251a40c9f48e2fca3f)
- [refactor(probitas-builder,probitas-runner): Move utilities into utils](/jsr-probitas/probitas/commit/e2f97268b9504800d5f306d71c76918044b7ee93)
- [refactor(probitas-builder,probitas-runner): Move utilities into utils](/jsr-probitas/probitas/commit/e2f97268b9504800d5f306d71c76918044b7ee93)
- [refactor(probitas-runner): Avoid complex type in runner](/jsr-probitas/probitas/commit/80329963bb8ea88293ba5e98b2294d438380f5f0)





---

To make edits to this PR:

```sh
git fetch upstream release-2025-12-08-23-25-57 && git checkout -b release-2025-12-08-23-25-57 upstream/release-2025-12-08-23-25-57
```
