### PR TITLE
chore: release 2025.12.15

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,63 @@
+### 2025.12.15
+
+#### @probitas/builder 0.2.9 (patch)
+
+- docs(*): update documentation for 0.6.0 release
+- refactor(@probitas/builder): store absolute paths in Source.file
+- refactor(*): use jsr: specifier in example scenarios
+
+#### @probitas/cli 0.6.0 (minor)
+
+- BREAKING(@probitas/cli): remove init command
+- feat(@probitas/cli): add Worker-based parallel execution infrastructure
+- docs(*): update documentation for 0.6.0 release
+- refactor(@probitas/cli): remove obsolete import map for subprocess execution
+- refactor(@probitas/cli): migrate config to probitas.json format
+- refactor(@probitas/cli): migrate list command to in-process execution
+- refactor(@probitas/cli): migrate run command from subprocess to Worker
+  execution
+- refactor(*): use jsr: specifier in example scenarios
+
+#### @probitas/discover 0.2.9 (patch)
+
+- docs(*): update documentation for 0.6.0 release
+- refactor(*): use jsr: specifier in example scenarios
+
+#### @probitas/expect 0.2.1 (patch)
+
+- docs(*): update documentation for 0.6.0 release
+- refactor(*): use jsr: specifier in example scenarios
+
+#### @probitas/logger 0.2.9 (patch)
+
+- docs(*): update documentation for 0.6.0 release
+- refactor(*): use jsr: specifier in example scenarios
+
+#### @probitas/probitas 0.5.1 (patch)
+
+- docs(*): update documentation for 0.6.0 release
+- refactor(*): use jsr: specifier in example scenarios
+
+#### @probitas/reporter 0.4.0 (minor)
+
+- BREAKING(@probitas/runner,@probitas/reporter): change Reporter interface to
+  use Metadata types
+- feat(@probitas/reporter): add cwd option for relative path display
+- docs(*): update documentation for 0.6.0 release
+- refactor(*): use jsr: specifier in example scenarios
+
+#### @probitas/runner 0.3.0 (minor)
+
+- BREAKING(@probitas/runner,@probitas/reporter): change Reporter interface to
+  use Metadata types
+- docs(*): update documentation for 0.6.0 release
+- refactor(*): use jsr: specifier in example scenarios
+
+#### @probitas/scenario 0.2.9 (patch)
+
+- docs(*): update documentation for 0.6.0 release
+- refactor(*): use jsr: specifier in example scenarios
+
 ### 2025.12.12
 
 #### @probitas/builder 0.2.8 (patch)

--- a/packages/probitas-builder/deno.json
+++ b/packages/probitas-builder/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/builder",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-cli/deno.json
+++ b/packages/probitas-cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-discover/deno.json
+++ b/packages/probitas-discover/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/discover",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-expect/deno.json
+++ b/packages/probitas-expect/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/expect",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-logger/deno.json
+++ b/packages/probitas-logger/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/logger",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-reporter/deno.json
+++ b/packages/probitas-reporter/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/reporter",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-runner/deno.json
+++ b/packages/probitas-runner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/runner",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-scenario/deno.json
+++ b/packages/probitas-scenario/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/scenario",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas/deno.json
+++ b/packages/probitas/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/probitas",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "exports": {
     ".": "./mod.ts",
     "./expect": "./expect.ts",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@probitas/builder|0.2.8|0.2.9|patch|
|@probitas/cli|0.5.0|0.6.0|minor|
|@probitas/discover|0.2.8|0.2.9|patch|
|@probitas/expect|0.2.0|0.2.1|patch|
|@probitas/logger|0.2.8|0.2.9|patch|
|@probitas/probitas|0.5.0|0.5.1|patch|
|@probitas/reporter|0.3.3|0.4.0|minor|
|@probitas/runner|0.2.8|0.3.0|minor|
|@probitas/scenario|0.2.8|0.2.9|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly

The following commits are not recognized. Please handle them manually if necessary:

- [Merge pull request #34 from jsr-probitas/feat/in-process-execution](/jsr-probitas/probitas/commit/aad4587e41ad68f230ef6ed7e3e48b3ee62880cd)





The following commits are ignored:

- [chore: Add --unstable-kv flag to probitas task in deno.jsonc](/jsr-probitas/probitas/commit/09422a93b21bc0b5b18d0f8abcb468c8e238bd6e)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-12-15-07-55-19 && git checkout -b release-2025-12-15-07-55-19 upstream/release-2025-12-15-07-55-19
```
