### PR TITLE
chore: release 2025.12.16

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,39 @@
 ### 2025.12.16
 
+#### @probitas/builder 0.3.1 (patch)
+
+- refactor(*): move CLI to separate repository
+
+#### @probitas/core 0.1.1 (patch)
+
+- refactor(*): move CLI to separate repository
+
+#### @probitas/discover 0.2.11 (patch)
+
+- refactor(*): move CLI to separate repository
+
+#### @probitas/expect 0.2.3 (patch)
+
+- refactor(*): move CLI to separate repository
+
+#### @probitas/logger 0.2.11 (patch)
+
+- refactor(*): move CLI to separate repository
+
+#### @probitas/probitas 0.5.3 (patch)
+
+- refactor(*): move CLI to separate repository
+
+#### @probitas/reporter 0.5.1 (patch)
+
+- refactor(*): move CLI to separate repository
+
+#### @probitas/runner 0.3.2 (patch)
+
+- refactor(*): move CLI to separate repository
+
+### 2025.12.16
+
 #### @probitas/cli 0.7.1 (patch)
 
 - feat(@probitas/cli): enable logging in worker processes

--- a/packages/probitas-builder/deno.json
+++ b/packages/probitas-builder/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/builder",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-core/deno.json
+++ b/packages/probitas-core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "exports": {
     ".": "./mod.ts",
     "./loader": "./loader.ts",

--- a/packages/probitas-discover/deno.json
+++ b/packages/probitas-discover/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/discover",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-expect/deno.json
+++ b/packages/probitas-expect/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/expect",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-logger/deno.json
+++ b/packages/probitas-logger/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/logger",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-reporter/deno.json
+++ b/packages/probitas-reporter/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/reporter",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-runner/deno.json
+++ b/packages/probitas-runner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/runner",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas/deno.json
+++ b/packages/probitas/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/probitas",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "exports": {
     ".": "./mod.ts",
     "./expect": "./expect.ts",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@probitas/builder|0.3.0|0.3.1|patch|
|@probitas/core|0.1.0|0.1.1|patch|
|@probitas/discover|0.2.10|0.2.11|patch|
|@probitas/expect|0.2.2|0.2.3|patch|
|@probitas/logger|0.2.10|0.2.11|patch|
|@probitas/probitas|0.5.2|0.5.3|patch|
|@probitas/reporter|0.5.0|0.5.1|patch|
|@probitas/runner|0.3.1|0.3.2|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly



The following commits have unknown scopes. Please handle them manually if necessary:

- [feat(@probitas/cli): add shell installer for pre-built binaries](/jsr-probitas/probitas/commit/f8e78b7d4bf39736c705dd86bad31c4b71e28618)
- [fix(@probitas/cli): remove unsupported Windows ARM64 target from release assets](/jsr-probitas/probitas/commit/1c7df11c20754a2d133e0ec16a6fe851910ceb4b)



The following commits are ignored:

- [docs: update Nix installation to reference CLI repository](/jsr-probitas/probitas/commit/fa857fe6d32e7a6041d79f4e4a484f010aae7925)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-12-16-17-43-00 && git checkout -b release-2025-12-16-17-43-00 upstream/release-2025-12-16-17-43-00
```
