### PR TITLE
chore: release 2025.12.17

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,61 @@
+### 2025.12.17
+
+#### @probitas/builder 0.3.2 (patch)
+
+- docs(*): fix docstring examples to pass --doc type checking
+- docs(*): reorganize .claude documentation structure
+- refactor(*): move --doc flag from test to check task
+
+#### @probitas/core 0.1.2 (patch)
+
+- fix(@probitas/core,@probitas/discover,@probitas/reporter): remove redundant
+  error logging
+- docs(*): fix docstring examples to pass --doc type checking
+- docs(*): reorganize .claude documentation structure
+- refactor(*): move --doc flag from test to check task
+
+#### @probitas/discover 0.2.12 (patch)
+
+- fix(@probitas/core,@probitas/discover,@probitas/reporter): remove redundant
+  error logging
+- docs(*): fix docstring examples to pass --doc type checking
+- docs(*): reorganize .claude documentation structure
+- refactor(*): move --doc flag from test to check task
+
+#### @probitas/expect 0.2.4 (patch)
+
+- docs(*): fix docstring examples to pass --doc type checking
+- docs(*): reorganize .claude documentation structure
+- refactor(*): move --doc flag from test to check task
+
+#### @probitas/logger 0.2.12 (patch)
+
+- docs(*): fix docstring examples to pass --doc type checking
+- docs(*): reorganize .claude documentation structure
+- refactor(*): move --doc flag from test to check task
+
+#### @probitas/probitas 0.5.4 (patch)
+
+- docs(*): fix docstring examples to pass --doc type checking
+- docs(*): reorganize .claude documentation structure
+- refactor(*): move --doc flag from test to check task
+- refactor(@probitas/probitas): use {module}.ts for submodule entry points
+
+#### @probitas/reporter 0.5.2 (patch)
+
+- fix(@probitas/core,@probitas/discover,@probitas/reporter): remove redundant
+  error logging
+- docs(*): fix docstring examples to pass --doc type checking
+- docs(*): reorganize .claude documentation structure
+- refactor(*): move --doc flag from test to check task
+
+#### @probitas/runner 0.3.3 (patch)
+
+- docs(*): fix docstring examples to pass --doc type checking
+- docs(*): reorganize .claude documentation structure
+- refactor(*): move --doc flag from test to check task
+- refactor(@probitas/runner): rename testutil.ts to _testutils.ts
+
 ### 2025.12.16
 
 #### @probitas/builder 0.3.1 (patch)

--- a/packages/probitas-builder/deno.json
+++ b/packages/probitas-builder/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/builder",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-core/deno.json
+++ b/packages/probitas-core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "exports": {
     ".": "./mod.ts",
     "./loader": "./loader.ts",

--- a/packages/probitas-discover/deno.json
+++ b/packages/probitas-discover/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/discover",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-expect/deno.json
+++ b/packages/probitas-expect/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/expect",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-logger/deno.json
+++ b/packages/probitas-logger/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/logger",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-reporter/deno.json
+++ b/packages/probitas-reporter/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/reporter",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-runner/deno.json
+++ b/packages/probitas-runner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/runner",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas/deno.json
+++ b/packages/probitas/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/probitas",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "exports": {
     ".": "./mod.ts",
     "./expect": "./expect.ts",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@probitas/builder|0.3.1|0.3.2|patch|
|@probitas/core|0.1.1|0.1.2|patch|
|@probitas/discover|0.2.11|0.2.12|patch|
|@probitas/expect|0.2.3|0.2.4|patch|
|@probitas/logger|0.2.11|0.2.12|patch|
|@probitas/probitas|0.5.3|0.5.4|patch|
|@probitas/reporter|0.5.1|0.5.2|patch|
|@probitas/runner|0.3.2|0.3.3|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [chore: add default selectors to probitas.json](/jsr-probitas/probitas/commit/5732eb007272bc06ad99e94a7de9824eb0b70411)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-12-17-10-27-16 && git checkout -b release-2025-12-17-10-27-16 upstream/release-2025-12-17-10-27-16
```
