### PR TITLE
fix(@probitas/expect): adjust matcher function types to use 'any' ins…

### DIFF
--- a/packages/probitas-expect/connectrpc.ts
+++ b/packages/probitas-expect/connectrpc.ts
@@ -249,9 +249,10 @@ export interface ConnectRpcResponseExpectation {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveHeadersPropertySatisfying<I>(
+  toHaveHeadersPropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**
@@ -320,9 +321,10 @@ export interface ConnectRpcResponseExpectation {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveTrailersPropertySatisfying<I>(
+  toHaveTrailersPropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**
@@ -348,7 +350,8 @@ export interface ConnectRpcResponseExpectation {
    * @param matcher - A function that receives the data and performs assertions
    */
   toHaveDataSatisfying(
-    matcher: (value: Record<string, unknown> | null) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: Record<string, any> | null) => void,
   ): this;
 
   /**
@@ -411,9 +414,10 @@ export interface ConnectRpcResponseExpectation {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveDataPropertySatisfying<I>(
+  toHaveDataPropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**

--- a/packages/probitas-expect/deno_kv/get.ts
+++ b/packages/probitas-expect/deno_kv/get.ts
@@ -109,7 +109,8 @@ export interface DenoKvGetResultExpectation<_T = unknown> {
    * Asserts that the value satisfies the provided matcher function.
    * @param matcher - A function that receives the value and performs assertions
    */
-  toHaveValueSatisfying(matcher: (value: unknown) => void): this;
+  // deno-lint-ignore no-explicit-any
+  toHaveValueSatisfying(matcher: (value: any) => void): this;
 
   /**
    * Asserts that the value is present (not null or undefined).
@@ -171,9 +172,10 @@ export interface DenoKvGetResultExpectation<_T = unknown> {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveValuePropertySatisfying<I>(
+  toHaveValuePropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**

--- a/packages/probitas-expect/graphql.ts
+++ b/packages/probitas-expect/graphql.ts
@@ -189,9 +189,10 @@ export interface GraphqlResponseExpectation {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveHeadersPropertySatisfying<I>(
+  toHaveHeadersPropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**
@@ -216,7 +217,8 @@ export interface GraphqlResponseExpectation {
    * Asserts that the error satisfies the provided matcher function.
    * @param matcher - A function that receives the error and performs assertions
    */
-  toHaveErrorSatisfying(matcher: (value: unknown) => void): this;
+  // deno-lint-ignore no-explicit-any
+  toHaveErrorSatisfying(matcher: (value: any) => void): this;
 
   /**
    * Asserts that the error is present (not null or undefined).
@@ -261,7 +263,8 @@ export interface GraphqlResponseExpectation {
    * @param matcher - A function that receives the extensions and performs assertions
    */
   toHaveExtensionsSatisfying(
-    matcher: (value: Record<string, unknown>) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: Record<string, any>) => void,
   ): this;
 
   /**
@@ -304,9 +307,10 @@ export interface GraphqlResponseExpectation {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveExtensionsPropertySatisfying<I>(
+  toHaveExtensionsPropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**
@@ -351,7 +355,8 @@ export interface GraphqlResponseExpectation {
    * Asserts that the data satisfies the provided matcher function.
    * @param matcher - A function that receives the data and performs assertions
    */
-  toHaveDataSatisfying(matcher: (value: unknown) => void): this;
+  // deno-lint-ignore no-explicit-any
+  toHaveDataSatisfying(matcher: (value: any) => void): this;
 
   /**
    * Asserts that the data matches the specified subset.
@@ -393,9 +398,10 @@ export interface GraphqlResponseExpectation {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveDataPropertySatisfying<I>(
+  toHaveDataPropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**

--- a/packages/probitas-expect/grpc.ts
+++ b/packages/probitas-expect/grpc.ts
@@ -256,9 +256,10 @@ export interface GrpcResponseExpectation {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveHeadersPropertySatisfying<I>(
+  toHaveHeadersPropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**
@@ -327,9 +328,10 @@ export interface GrpcResponseExpectation {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveTrailersPropertySatisfying<I>(
+  toHaveTrailersPropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**
@@ -355,7 +357,8 @@ export interface GrpcResponseExpectation {
    * @param matcher - A function that receives the data and performs assertions
    */
   toHaveDataSatisfying(
-    matcher: (value: Record<string, unknown> | null) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: Record<string, any> | null) => void,
   ): this;
 
   /**
@@ -418,9 +421,10 @@ export interface GrpcResponseExpectation {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveDataPropertySatisfying<I>(
+  toHaveDataPropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**

--- a/packages/probitas-expect/grpc_test.ts
+++ b/packages/probitas-expect/grpc_test.ts
@@ -79,7 +79,8 @@ const EXPECTED_METHODS: Record<keyof GrpcResponseExpectation, unknown[]> = {
   toHaveTrailersEqual: [],
   toHaveTrailersStrictEqual: [],
   toHaveTrailersSatisfying: [
-    (v: Record<string, unknown>) => assertExists(v),
+    // deno-lint-ignore no-explicit-any
+    (v: Record<string, any>) => assertExists(v),
   ],
   toHaveTrailersMatching: [{ "grpc-status": "0" }],
   toHaveTrailersProperty: ["grpc-status"],
@@ -94,7 +95,8 @@ const EXPECTED_METHODS: Record<keyof GrpcResponseExpectation, unknown[]> = {
   toHaveDataEqual: [],
   toHaveDataStrictEqual: [],
   toHaveDataSatisfying: [
-    (v: Record<string, unknown> | null) => assertExists(v),
+    // deno-lint-ignore no-explicit-any
+    (v: Record<string, any> | null) => assertExists(v),
   ],
   toHaveDataPresent: [],
   toHaveDataNull: [],

--- a/packages/probitas-expect/http.ts
+++ b/packages/probitas-expect/http.ts
@@ -227,9 +227,10 @@ export interface HttpResponseExpectation {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveHeadersPropertySatisfying<I>(
+  toHaveHeadersPropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**
@@ -511,7 +512,8 @@ export interface HttpResponseExpectation {
    * @param matcher - A function that receives the JSON and performs assertions
    */
   toHaveJsonSatisfying(
-    matcher: (value: Record<string, unknown> | null) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: Record<string, any> | null) => void,
   ): this;
 
   /**
@@ -574,9 +576,10 @@ export interface HttpResponseExpectation {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveJsonPropertySatisfying<I>(
+  toHaveJsonPropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**

--- a/packages/probitas-expect/http_test.ts
+++ b/packages/probitas-expect/http_test.ts
@@ -194,7 +194,8 @@ const EXPECTED_METHODS: Record<keyof HttpResponseExpectation, unknown[]> = {
   toHaveJsonEqual: [],
   toHaveJsonStrictEqual: [],
   toHaveJsonSatisfying: [
-    (v: Record<string, unknown> | null) => assertExists(v),
+    // deno-lint-ignore no-explicit-any
+    (v: Record<string, any> | null) => assertExists(v),
   ],
   toHaveJsonPresent: [],
   toHaveJsonNull: [],

--- a/packages/probitas-expect/mongodb/find_one.ts
+++ b/packages/probitas-expect/mongodb/find_one.ts
@@ -118,9 +118,10 @@ export interface MongoFindOneResultExpectation<_T = unknown> {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveDocPropertySatisfying<I>(
+  toHaveDocPropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**

--- a/packages/probitas-expect/rabbitmq/consume.ts
+++ b/packages/probitas-expect/rabbitmq/consume.ts
@@ -55,7 +55,8 @@ export interface RabbitMqConsumeResultExpectation {
    * Asserts that the message satisfies the provided matcher function.
    * @param matcher - A function that receives the message and performs assertions
    */
-  toHaveMessageSatisfying(matcher: (value: unknown) => void): this;
+  // deno-lint-ignore no-explicit-any
+  toHaveMessageSatisfying(matcher: (value: any) => void): this;
 
   /**
    * Asserts that the message is present (not null or undefined).
@@ -117,9 +118,10 @@ export interface RabbitMqConsumeResultExpectation {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveMessagePropertySatisfying<I>(
+  toHaveMessagePropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**
@@ -144,7 +146,8 @@ export interface RabbitMqConsumeResultExpectation {
    * Asserts that the content satisfies the provided matcher function.
    * @param matcher - A function that receives the content and performs assertions
    */
-  toHaveContentSatisfying(matcher: (value: unknown) => void): this;
+  // deno-lint-ignore no-explicit-any
+  toHaveContentSatisfying(matcher: (value: any) => void): this;
 
   /**
    * Asserts that the content is present (not null or undefined).

--- a/packages/probitas-expect/redis/common.ts
+++ b/packages/probitas-expect/redis/common.ts
@@ -53,7 +53,8 @@ export interface RedisCommonResultExpectation {
    * Asserts that the value satisfies the provided matcher function.
    * @param matcher - A function that receives the value and performs assertions
    */
-  toHaveValueSatisfying(matcher: (value: unknown) => void): this;
+  // deno-lint-ignore no-explicit-any
+  toHaveValueSatisfying(matcher: (value: any) => void): this;
 
   /**
    * Asserts that the duration equals the expected value.

--- a/packages/probitas-expect/redis/hash.ts
+++ b/packages/probitas-expect/redis/hash.ts
@@ -55,7 +55,8 @@ export interface RedisHashResultExpectation {
    * Asserts that the value satisfies the provided matcher function.
    * @param matcher - A function that receives the value and performs assertions
    */
-  toHaveValueSatisfying(matcher: (value: unknown) => void): this;
+  // deno-lint-ignore no-explicit-any
+  toHaveValueSatisfying(matcher: (value: any) => void): this;
 
   /**
    * Asserts that the value matches the specified subset.
@@ -97,9 +98,10 @@ export interface RedisHashResultExpectation {
    * @param keyPath - The key path to check
    * @param matcher - A function that receives the property value and performs assertions
    */
-  toHaveValuePropertySatisfying<I>(
+  toHaveValuePropertySatisfying(
     keyPath: string | string[],
-    matcher: (value: I) => void,
+    // deno-lint-ignore no-explicit-any
+    matcher: (value: any) => void,
   ): this;
 
   /**

--- a/packages/probitas-expect/sql.ts
+++ b/packages/probitas-expect/sql.ts
@@ -186,7 +186,8 @@ export interface SqlQueryResultExpectation {
    * Asserts that the last insert ID satisfies the provided matcher function.
    * @param matcher - A function that receives the last insert ID and performs assertions
    */
-  toHaveLastInsertIdSatisfying(matcher: (value: unknown) => void): this;
+  // deno-lint-ignore no-explicit-any
+  toHaveLastInsertIdSatisfying(matcher: (value: any) => void): this;
 
   /**
    * Asserts that the last insert ID is present (not null or undefined).


### PR DESCRIPTION
This pull request updates several expectation interfaces across multiple files to standardize matcher function types by using `any` instead of generic or `unknown` types. This change improves consistency and flexibility for assertion matchers, and adds `deno-lint-ignore no-explicit-any` comments to explicitly allow the use of `any` type. The update affects assertion methods for headers, trailers, data, errors, JSON, and other properties in various protocol and database expectation interfaces.

**Type Standardization and Linting:**

* Changed matcher function parameter types from generics or `unknown` to `any` in assertion methods for headers, trailers, data, errors, and property-satisfying methods in the following interfaces: `ConnectRpcResponseExpectation`, `GrpcResponseExpectation`, `GraphqlResponseExpectation`, `HttpResponseExpectation`, `DenoKvGetResultExpectation`, `MongoFindOneResultExpectation`, `RabbitMqConsumeResultExpectation`, `RedisCommonResultExpectation`, `RedisHashResultExpectation`, and `SqlQueryResultExpectation`. Added `deno-lint-ignore no-explicit-any` comments for each change. [[1]](diffhunk://#diff-7a5e1d4bbc891a48e6f960e65e891b59603a3d13630140d7867cdbabd8c31cb7L252-R255) [[2]](diffhunk://#diff-7a5e1d4bbc891a48e6f960e65e891b59603a3d13630140d7867cdbabd8c31cb7L323-R327) [[3]](diffhunk://#diff-7a5e1d4bbc891a48e6f960e65e891b59603a3d13630140d7867cdbabd8c31cb7L351-R354) [[4]](diffhunk://#diff-7a5e1d4bbc891a48e6f960e65e891b59603a3d13630140d7867cdbabd8c31cb7L414-R420) [[5]](diffhunk://#diff-b6b4817c6c72b2f28ef738735da543bd1ad70918025251dd2bd6bec19e36c31fL112-R113) [[6]](diffhunk://#diff-b6b4817c6c72b2f28ef738735da543bd1ad70918025251dd2bd6bec19e36c31fL174-R178) [[7]](diffhunk://#diff-27125d6b0ced1b859118876b2e8e9dd59dd48028e891fe3390bf42e37da18488L192-R195) [[8]](diffhunk://#diff-27125d6b0ced1b859118876b2e8e9dd59dd48028e891fe3390bf42e37da18488L219-R221) [[9]](diffhunk://#diff-27125d6b0ced1b859118876b2e8e9dd59dd48028e891fe3390bf42e37da18488L264-R267) [[10]](diffhunk://#diff-27125d6b0ced1b859118876b2e8e9dd59dd48028e891fe3390bf42e37da18488L307-R313) [[11]](diffhunk://#diff-27125d6b0ced1b859118876b2e8e9dd59dd48028e891fe3390bf42e37da18488L354-R359) [[12]](diffhunk://#diff-27125d6b0ced1b859118876b2e8e9dd59dd48028e891fe3390bf42e37da18488L396-R404) [[13]](diffhunk://#diff-49f7601a5c63353d6b02582d75ed13183af5c3ac4728a939637928020c8e4f55L259-R262) [[14]](diffhunk://#diff-49f7601a5c63353d6b02582d75ed13183af5c3ac4728a939637928020c8e4f55L330-R334) [[15]](diffhunk://#diff-49f7601a5c63353d6b02582d75ed13183af5c3ac4728a939637928020c8e4f55L358-R361) [[16]](diffhunk://#diff-49f7601a5c63353d6b02582d75ed13183af5c3ac4728a939637928020c8e4f55L421-R427) [[17]](diffhunk://#diff-842323ec52fbb45a5dcf76b3acefdbeab4f5310023d7a01b8d0870008e6b8480L230-R233) [[18]](diffhunk://#diff-842323ec52fbb45a5dcf76b3acefdbeab4f5310023d7a01b8d0870008e6b8480L514-R516) [[19]](diffhunk://#diff-842323ec52fbb45a5dcf76b3acefdbeab4f5310023d7a01b8d0870008e6b8480L577-R582) [[20]](diffhunk://#diff-fa81a36ad6d1e73aed53859cf28c28a22e07299e018c86b2e91cd9e31ed3326bL121-R124) [[21]](diffhunk://#diff-5e3eb5cd5729cde98616e916eaded8528ccc3379b4ff266f34c0a069a50d223cL58-R59) [[22]](diffhunk://#diff-5e3eb5cd5729cde98616e916eaded8528ccc3379b4ff266f34c0a069a50d223cL120-R124) [[23]](diffhunk://#diff-5e3eb5cd5729cde98616e916eaded8528ccc3379b4ff266f34c0a069a50d223cL147-R150) [[24]](diffhunk://#diff-f027ddcc4cc94130fcd6fad4657893a380cf7a7f026891272e2cadd64fbb7253L56-R57) [[25]](diffhunk://#diff-e294ec8954aecabdd2e6bb9ee9ef658b697c2474ada545ec2e0d831cb8b115fbL58-R59) [[26]](diffhunk://#diff-e294ec8954aecabdd2e6bb9ee9ef658b697c2474ada545ec2e0d831cb8b115fbL100-R104) [[27]](diffhunk://#diff-dbacdb7825c4f99f2f6324c9908ca682fe19c3c81bdb874f0ce4c10058713b2eL189-R190)

**Test Updates for Consistency:**

* Updated test files (`grpc_test.ts`, `http_test.ts`) to use matcher functions with the `any` type and added `deno-lint-ignore no-explicit-any` comments for consistency with the interface changes. [[1]](diffhunk://#diff-bd2972af2588a9dc9987c69256057bb4a13661449aac3dac1e6bf2bdf185e5e2L82-R83) [[2]](diffhunk://#diff-bd2972af2588a9dc9987c69256057bb4a13661449aac3dac1e6bf2bdf185e5e2L97-R99) [[3]](diffhunk://#diff-9eb582d51ff0eb4b20f66913ba236c0687d5351fd294afdeadd24512b497fe81L197-R198)

These changes ensure a uniform matcher signature across all expectation interfaces, making it easier to write flexible assertion logic for tests.…tead