### PR TITLE
Bump all package versions

### DIFF
--- a/packages/probitas-builder/deno.json
+++ b/packages/probitas-builder/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/builder",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-core/deno.json
+++ b/packages/probitas-core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "exports": {
     ".": "./mod.ts",
     "./loader": "./loader.ts",

--- a/packages/probitas-discover/deno.json
+++ b/packages/probitas-discover/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/discover",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-expect/deno.json
+++ b/packages/probitas-expect/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/expect",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-logger/deno.json
+++ b/packages/probitas-logger/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/logger",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-reporter/deno.json
+++ b/packages/probitas-reporter/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/reporter",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas-runner/deno.json
+++ b/packages/probitas-runner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/runner",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "exports": "./mod.ts",
   "publish": {
     "exclude": [

--- a/packages/probitas/deno.json
+++ b/packages/probitas/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/probitas",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "exports": {
     ".": "./mod.ts",
     "./expect": "./expect.ts",


### PR DESCRIPTION
## Summary
- Bump patch versions for all 8 packages in the workspace
- @probitas/builder: 0.4.2 → 0.4.3
- @probitas/core: 0.2.2 → 0.2.3
- @probitas/discover: 0.3.4 → 0.3.5
- @probitas/expect: 0.3.4 → 0.3.5
- @probitas/logger: 0.3.2 → 0.3.3
- @probitas/reporter: 0.6.2 → 0.6.3
- @probitas/runner: 0.4.2 → 0.4.3
- @probitas/probitas: 0.6.2 → 0.6.3

## Why
Manual version synchronization to align all packages in the workspace. This ensures consistent versioning across the monorepo and prepares for the next release cycle.

## Test Plan
- [ ] Verify all package versions are correctly updated in deno.json files
- [ ] Run `deno task verify` to ensure no breaking changes
- [ ] Confirm packages can be published to JSR with new versions