### PR TITLE
Fix release workflow authentication using gh auth setup-git

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ jobs:
 
       - uses: nixbuild/nix-quick-install-action@v34
 
+      - name: Configure gh auth for git
+        run: gh auth setup-git
+        env:
+          GH_TOKEN: ${{ secrets.PULL_REQUEST_TOKEN }}
+
       - name: Run release task
         run: |
           nix develop -c deno task release ${{ inputs.version }}

--- a/.scripts/release.ts
+++ b/.scripts/release.ts
@@ -177,80 +177,16 @@ async function createReleasePR(
     throw new Error("Failed to commit");
   }
 
-  // Configure remote URL with token (in CI environment)
-  if (isCI) {
-    const ghToken = Deno.env.get("GH_TOKEN");
-    if (!ghToken) {
-      throw new Error("GH_TOKEN environment variable is required in CI");
-    }
-
-    // Get the current remote URL to extract repo path
-    const getRemote = new Deno.Command("git", {
-      args: ["remote", "get-url", "origin"],
-      stdout: "piped",
-      stderr: "inherit",
-    });
-    const { code: getRemoteCode, stdout } = await getRemote.output();
-    if (getRemoteCode !== 0) {
-      throw new Error("Failed to get remote URL");
-    }
-
-    const remoteUrl = new TextDecoder().decode(stdout).trim();
-    // Extract owner/repo from URL (handles both HTTPS and git@ formats)
-    // Match exactly two path segments (owner and repo)
-    const repoMatch = remoteUrl.match(
-      /github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/,
-    );
-    if (!repoMatch) {
-      throw new Error(`Could not extract repo path from URL: ${remoteUrl}`);
-    }
-
-    const repoPath = repoMatch[1];
-    const authenticatedUrl =
-      `https://x-access-token:${ghToken}@github.com/${repoPath}`;
-
-    // Temporarily set the authenticated remote URL
-    const setUrl = new Deno.Command("git", {
-      args: ["remote", "set-url", "origin", authenticatedUrl],
-      stdout: "inherit",
-      stderr: "inherit",
-    });
-    const { code: setUrlCode } = await setUrl.output();
-    if (setUrlCode !== 0) {
-      throw new Error("Failed to set authenticated remote URL");
-    }
-
-    try {
-      // Push with authenticated URL
-      const push = new Deno.Command("git", {
-        args: ["push", "origin", branch],
-        stdout: "inherit",
-        stderr: "inherit",
-      });
-      const { code: pushCode } = await push.output();
-      if (pushCode !== 0) {
-        throw new Error("Failed to push branch");
-      }
-    } finally {
-      // Restore the original remote URL to avoid leaving the token in git config
-      const resetUrl = new Deno.Command("git", {
-        args: ["remote", "set-url", "origin", remoteUrl],
-        stdout: "inherit",
-        stderr: "inherit",
-      });
-      await resetUrl.output();
-    }
-  } else {
-    // Push without authentication (local environment)
-    const push = new Deno.Command("git", {
-      args: ["push", "origin", branch],
-      stdout: "inherit",
-      stderr: "inherit",
-    });
-    const { code: pushCode } = await push.output();
-    if (pushCode !== 0) {
-      throw new Error("Failed to push branch");
-    }
+  // Push branch
+  // In CI, gh auth setup ensures git push uses GH_TOKEN automatically
+  const push = new Deno.Command("git", {
+    args: ["push", "-u", "origin", branch],
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const { code: pushCode } = await push.output();
+  if (pushCode !== 0) {
+    throw new Error("Failed to push branch");
   }
 
   // Create PR
@@ -262,6 +198,22 @@ async function createReleasePR(
 ## Test plan
 - [ ] CI checks pass (verify, scenario-test, scenario-test-nix)
 - [ ] Ready to merge and trigger publish workflow`;
+
+  // Warn if GH_TOKEN is not set in local environment
+  if (!isCI && !Deno.env.get("GH_TOKEN")) {
+    console.warn(
+      "\n⚠️  Warning: GH_TOKEN environment variable is not set.",
+    );
+    console.warn(
+      "   The created PR will not trigger CI workflows.",
+    );
+    console.warn(
+      "   To enable CI on PR creation, set GH_TOKEN to a Personal Access Token",
+    );
+    console.warn(
+      "   with 'workflow' scope before running this command.\n",
+    );
+  }
 
   const pr = new Deno.Command("gh", {
     args: [


### PR DESCRIPTION
## Summary
- Add `gh auth setup-git` step in release workflow to configure git credentials
- Remove 60+ lines of manual git remote URL manipulation code
- Simplify push logic to use plain `git push -u origin branch`

## Why
The release workflow was failing with "Permission denied (publickey)" errors when attempting to push release branches. The previous approach of manually embedding tokens in git remote URLs was fragile and unreliable when working with actions/checkout.

GitHub's `gh auth setup-git` command is the officially recommended way to configure git authentication in GitHub Actions. It sets up git's credential helper to automatically use the `GH_TOKEN` environment variable for authentication, which is more robust and eliminates the need for URL manipulation.

This change makes the authentication mechanism simpler, more maintainable, and aligns with GitHub's best practices.

## Test Plan
- [ ] Manually trigger release workflow and verify it can push branches successfully
- [ ] Verify PR creation works after branch push
- [ ] Confirm no authentication errors in workflow logs
- [ ] Test that local environment still works (with appropriate warning if GH_TOKEN not set)