### PR TITLE
Fix gh auth setup-git to run in same step as git push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,9 @@ jobs:
 
       - uses: nixbuild/nix-quick-install-action@v34
 
-      - name: Configure gh auth for git
-        run: gh auth setup-git
-        env:
-          GH_TOKEN: ${{ secrets.PULL_REQUEST_TOKEN }}
-
       - name: Run release task
         run: |
+          gh auth setup-git
           nix develop -c deno task release ${{ inputs.version }}
         env:
           GH_TOKEN: ${{ secrets.PULL_REQUEST_TOKEN }}


### PR DESCRIPTION
## Summary
- Move `gh auth setup-git` from separate workflow step into the release task step
- Ensure git credential configuration persists when `git push` executes

## Why
The previous fix (#68) added `gh auth setup-git` to configure git authentication, but it was placed in a separate workflow step. This didn't work because GitHub Actions steps run in independent shell environments—git credential configuration from one step doesn't persist to the next.

By moving `gh auth setup-git` into the same step as `nix develop -c deno task release`, the git credential helper is configured in the same shell environment where `git push` executes. This ensures the authentication works correctly.

## Test Plan
- [ ] Manually trigger release workflow and verify it can push branches successfully
- [ ] Verify PR creation works after branch push
- [ ] Confirm no authentication errors in workflow logs