### PR TITLE
Authenticate gh CLI with GH_TOKEN before git credential setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Run release task
         run: |
+          set -e
+          gh auth login --with-token <<<"$GH_TOKEN"
           gh auth setup-git
           nix develop -c deno task release ${{ inputs.version }}
         env:


### PR DESCRIPTION
## Summary
- Add `gh auth login --with-token` to authenticate gh CLI with GH_TOKEN
- Move `gh auth setup-git` into the same step as the release task
- Ensure git credential helper uses the correct token

## Why
The previous fixes attempted to use `gh auth setup-git` to configure git authentication, but it still failed because `gh auth setup-git` uses the gh CLI's current authentication state, not the `GH_TOKEN` environment variable directly.

The gh CLI in GitHub Actions runners may be authenticated with a different account (or not authenticated at all). By adding `gh auth login --with-token` before `gh auth setup-git`, we explicitly authenticate the gh CLI with the `GH_TOKEN` value, ensuring that the git credential helper is configured with the correct token.

## Test Plan
- [ ] Manually trigger release workflow and verify it can push branches successfully
- [ ] Verify PR creation works after branch push
- [ ] Confirm no authentication errors in workflow logs