### PR TITLE
Refactor release workflow to use GitHub Actions Marketplace action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,37 @@ jobs:
 
       - uses: nixbuild/nix-quick-install-action@v34
 
-      - name: Run release task
+      - name: Parse version
+        id: version
         run: |
-          set -e
-          gh auth login --with-token <<<"$GH_TOKEN"
-          gh auth setup-git
-          nix develop -c deno task release ${{ inputs.version }}
-        env:
-          GH_TOKEN: ${{ secrets.PULL_REQUEST_TOKEN }}
+          VERSION="${{ inputs.version }}"
+          # Remove 'v' prefix if present
+          VERSION_NO_V="${VERSION#v}"
+          TAG="v${VERSION_NO_V}"
+          echo "version=${VERSION_NO_V}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+      - name: Run release task
+        run: nix develop -c deno task release ${{ steps.version.outputs.tag }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.PULL_REQUEST_TOKEN }}
+          commit-message: "chore: bump version to ${{ steps.version.outputs.version }}"
+          branch: release/${{ steps.version.outputs.tag }}
+          delete-branch: true
+          title: "chore: bump version to ${{ steps.version.outputs.version }}"
+          body: |
+            ## Summary
+            - Update version to ${{ steps.version.outputs.version }} in deno.json
+            - Update deno.lock to reflect new version
+            - Update flake.lock with latest dependencies
+
+            ## Test plan
+            - [ ] CI checks pass (verify, scenario-test, scenario-test-nix)
+            - [ ] Ready to merge and trigger publish workflow
+          labels: release
+          assignees: ${{ github.actor }}
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>

--- a/.scripts/release.ts
+++ b/.scripts/release.ts
@@ -1,20 +1,20 @@
 #!/usr/bin/env -S deno run -A
 /**
- * Prepare a release by updating version, dependencies, and creating a PR
+ * Prepare a release by updating version and dependencies
  *
  * Usage:
- *   deno task release <version>          # Create PR
- *   deno task release <version> --skip-pr  # Skip PR creation
+ *   deno task release <version>
  *
  * Examples:
  *   deno task release v1.2.3
- *   deno task release 1.2.3 --skip-pr
+ *   deno task release 1.2.3
  *
  * This script performs:
  * 1. Update version in deno.json
  * 2. Update deno.lock with new version
  * 3. Update flake.lock (if Nix is available)
- * 4. Create release branch and PR (unless --skip-pr is specified)
+ *
+ * Note: Branch creation and PR creation are handled by GitHub Actions workflow
  *
  * @module
  */
@@ -101,153 +101,13 @@ async function updateFlakeLock(): Promise<void> {
   console.log("✓ Updated flake.lock");
 }
 
-async function createReleasePR(
-  version: string,
-  tag: string,
-  skipPR: boolean,
-): Promise<void> {
-  if (skipPR) {
-    console.log("\n⊘ Skipping PR creation (--skip-pr specified)");
-    console.log("You can manually create a PR with:");
-    console.log(`  git checkout -b release/${tag}`);
-    console.log(`  git add deno.json deno.lock flake.lock`);
-    console.log(`  git commit -m "chore: bump version to ${version}"`);
-    console.log(`  git push origin release/${tag}`);
-    console.log(`  gh pr create --base main --head release/${tag}`);
-    return;
-  }
-
-  console.log("\nCreating release PR...");
-  const branch = `release/${tag}`;
-
-  // Configure git (only in CI environment)
-  const isCI = Deno.env.get("CI") === "true";
-  if (isCI) {
-    const gitConfigName = new Deno.Command("git", {
-      args: ["config", "user.name", "github-actions[bot]"],
-    });
-    const { code: gitConfigNameCode } = await gitConfigName.output();
-    if (gitConfigNameCode !== 0) {
-      throw new Error("Failed to configure git user.name");
-    }
-
-    const gitConfigEmail = new Deno.Command("git", {
-      args: [
-        "config",
-        "user.email",
-        "github-actions[bot]@users.noreply.github.com",
-      ],
-    });
-    const { code: gitConfigEmailCode } = await gitConfigEmail.output();
-    if (gitConfigEmailCode !== 0) {
-      throw new Error("Failed to configure git user.email");
-    }
-  }
-
-  // Create and checkout branch
-  const checkout = new Deno.Command("git", {
-    args: ["checkout", "-b", branch],
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  const { code: checkoutCode } = await checkout.output();
-  if (checkoutCode !== 0) {
-    throw new Error("Failed to create branch");
-  }
-
-  // Add files
-  const add = new Deno.Command("git", {
-    args: ["add", "deno.json", "deno.lock", "flake.lock"],
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  const { code: addCode } = await add.output();
-  if (addCode !== 0) {
-    throw new Error("Failed to add files");
-  }
-
-  // Commit
-  const commit = new Deno.Command("git", {
-    args: ["commit", "-m", `chore: bump version to ${version}`],
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  const { code: commitCode } = await commit.output();
-  if (commitCode !== 0) {
-    throw new Error("Failed to commit");
-  }
-
-  // Push branch
-  // In CI, gh auth setup ensures git push uses GH_TOKEN automatically
-  const push = new Deno.Command("git", {
-    args: ["push", "-u", "origin", branch],
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  const { code: pushCode } = await push.output();
-  if (pushCode !== 0) {
-    throw new Error("Failed to push branch");
-  }
-
-  // Create PR
-  const prBody = `## Summary
-- Update version to ${version} in deno.json
-- Update deno.lock to reflect new version
-- Update flake.lock with latest dependencies
-
-## Test plan
-- [ ] CI checks pass (verify, scenario-test, scenario-test-nix)
-- [ ] Ready to merge and trigger publish workflow`;
-
-  // Warn if GH_TOKEN is not set in local environment
-  if (!isCI && !Deno.env.get("GH_TOKEN")) {
-    console.warn(
-      "\n⚠️  Warning: GH_TOKEN environment variable is not set.",
-    );
-    console.warn(
-      "   The created PR will not trigger CI workflows.",
-    );
-    console.warn(
-      "   To enable CI on PR creation, set GH_TOKEN to a Personal Access Token",
-    );
-    console.warn(
-      "   with 'workflow' scope before running this command.\n",
-    );
-  }
-
-  const pr = new Deno.Command("gh", {
-    args: [
-      "pr",
-      "create",
-      "--title",
-      `chore: bump version to ${version}`,
-      "--body",
-      prBody,
-      "--base",
-      "main",
-      "--head",
-      branch,
-    ],
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  const { code: prCode } = await pr.output();
-  if (prCode !== 0) {
-    throw new Error("Failed to create PR");
-  }
-
-  console.log(`✓ Created PR for release/${tag}`);
-}
-
 if (import.meta.main) {
   const args = Deno.args;
-  const skipPR = args.includes("--skip-pr");
-  const versionInput = args.find((arg) => !arg.startsWith("--"));
+  const versionInput = args[0];
 
   if (!versionInput) {
-    console.error("Usage: deno task release <version> [--skip-pr]");
+    console.error("Usage: deno task release <version>");
     console.error("Example: deno task release v1.2.3");
-    console.error("         deno task release v1.2.3 --skip-pr");
     Deno.exit(1);
   }
 
@@ -259,9 +119,12 @@ if (import.meta.main) {
     await updateVersion(version);
     await updateLock();
     await updateFlakeLock();
-    await createReleasePR(version, tag, skipPR);
 
     console.log(`\n✓ Release preparation complete!`);
+    console.log(`✓ Files updated: deno.json, deno.lock, flake.lock`);
+    console.log(
+      `\n⚠️  Next: GitHub Actions will create a PR for release/${tag}`,
+    );
   } catch (error) {
     console.error(
       `\n✗ Error: ${error instanceof Error ? error.message : error}`,


### PR DESCRIPTION
## Summary
- Removed git operations from `release.ts` (branch, commit, push, PR creation)
- Added `peter-evans/create-pull-request@v7` action to release workflow
- Added version parsing step for cleaner output reuse
- Simplified release script to only handle file updates

## Why
The previous approach mixed local script responsibilities (file updates) with CI concerns (git operations, PR creation), leading to:
- Complex gh CLI authentication setup in the workflow
- Redundant git configuration between script and CI
- Less declarative workflow definition

This refactoring separates concerns:
- `release.ts`: Pure file transformation (update versions, regenerate locks)
- GitHub Actions: Git operations and PR lifecycle (using official marketplace action)

Benefits:
- **Simpler authentication**: No manual gh auth setup required
- **More declarative**: Workflow configuration is clear and maintainable
- **Better error handling**: Built into the marketplace action
- **Idempotent**: Action handles existing branches gracefully

## Test Plan
- [ ] Trigger release workflow with a test version
- [ ] Verify files are updated correctly (deno.json, deno.lock, flake.lock)
- [ ] Verify PR is created with correct branch name, labels, and assignee
- [ ] Verify CI checks run on the created PR