### PR TITLE
fix(*): redirect shell hook message to stderr

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
               pkgs.sqlite
               pkgs.duckdb
             ]}:$LD_LIBRARY_PATH"
-            echo "Entering Probitas development environment"
+            echo "Entering Probitas development environment" >&2
           '';
         };
       }


### PR DESCRIPTION
## Summary
- Redirect Nix flake's shellHook message from stdout to stderr

## Why
The publish CI workflow was failing because the Nix development shell's welcome message ("Entering Probitas development environment") was being output to stdout. When GitHub Actions executed `nix develop -c deno eval` to extract the version number, this message contaminated the output, causing `GITHUB_OUTPUT` to receive an invalid format and fail the workflow.

By redirecting the message to stderr using `>&2`, stdout remains clean for machine-readable output, allowing CI/CD pipelines to properly extract version information and other programmatic data.

## Test Plan
- [ ] Verify `deno task verify` passes locally
- [ ] Confirm that `nix develop -c deno eval "console.log(JSON.parse(Deno.readTextFileSync('deno.json')).version)"` outputs only the version number to stdout
- [ ] Monitor the publish workflow succeeds when this PR is merged and a new release is created