### PR TITLE
Enable manual dispatch for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,10 +6,16 @@ on:
       - closed
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to publish (branch, tag, or commit SHA)"
+        required: false
+        default: "main"
 
 jobs:
   publish:
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -20,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ github.event.inputs.ref || 'main' }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: nixbuild/nix-quick-install-action@v34


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to publish workflow
- Allow specifying custom ref (branch, tag, or commit SHA) for manual runs
- Update job condition to support both automated and manual publishing

## Why
The publish workflow previously only ran automatically when release PRs were merged. This limitation meant that emergency republishing or testing the publish process required creating a full release PR, even for urgent fixes or testing scenarios.

Adding `workflow_dispatch` provides operational flexibility by allowing manual triggering of the publish workflow through GitHub Actions UI, enabling:
- Emergency republishing without waiting for release PR flow
- Testing publish process before actual release
- Recovery from failed publish attempts without code changes

## Test Plan
- [ ] Verify automated publish still works on release PR merge
- [ ] Test manual dispatch with default ref (main)
- [ ] Test manual dispatch with custom ref