### PR TITLE
Separate update-homebrew into independent reusable workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,12 +81,6 @@ jobs:
 
   update-homebrew:
     needs: ["publish"]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          repository: probitas-test/homebrew-tap
-          event-type: update-formula
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+    if: needs.publish.result == 'success'
+    uses: ./.github/workflows/update-homebrew.yml
+    secrets: inherit

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,18 @@
+name: Update Homebrew
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  update-homebrew:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Trigger Homebrew formula update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          repository: probitas-test/homebrew-tap
+          event-type: update-formula


### PR DESCRIPTION
## Summary
- Extract update-homebrew step from publish.yml into dedicated update-homebrew.yml
- Make update-homebrew callable via workflow_call and workflow_dispatch
- Add conditional execution to skip when publish is skipped

## Why
The previous implementation had update-homebrew as a job within publish.yml, which made it:
- Impossible to trigger manually without running the entire publish workflow
- Tightly coupled to the publish workflow structure
- Always executed even when publish was skipped (using `success()` instead of checking actual result)

By separating it into a reusable workflow:
- Manual updates can be triggered independently via workflow_dispatch
- The publish workflow becomes cleaner and more focused
- Proper conditional execution ensures it only runs when publish actually succeeds
- No parameters are needed since the Homebrew tap pulls version info directly from JSR

## Test Plan
- [ ] Verify update-homebrew is triggered after successful publish
- [ ] Verify update-homebrew is skipped when publish is skipped
- [ ] Test manual execution via workflow_dispatch