### PR TITLE
fix: Install script URL assignment correction

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ fi
 PACKAGE_NAME="@probitas/probitas"
 COMMAND_NAME="probitas"
 SUBMODULE_PATH="/cli"
-JSR_BASE_URL=`https://jsr.io/${PACKAGE_NAME}`
+JSR_BASE_URL="https://jsr.io/${PACKAGE_NAME}"
 
 # Read configuration from environment variables
 VERSION="${PROBITAS_VERSION:-}"


### PR DESCRIPTION
This pull request makes a minor fix to the `install.sh` script, replacing backticks with double quotes in the assignment of the `JSR_BASE_URL` variable to ensure proper URL formatting.