### PR TITLE
chore: bump version to 0.14.1

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/probitas",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "exports": {
     ".": "./src/mod.ts",
     "./cli": "./src/cli.ts",

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766747458,
-        "narHash": "sha256-m63jjuo/ygo8ztkCziYh5OOIbTSXUDkKbqw3Vuqu4a4=",
+        "lastModified": 1766870016,
+        "narHash": "sha256-fHmxAesa6XNqnIkcS6+nIHuEmgd/iZSP/VXxweiEuQw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c633f572eded8c4f3c75b8010129854ed404a6ce",
+        "rev": "5c2bc52fb9f8c264ed6c93bd20afa2ff5e763dce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Update version to 0.14.1 in deno.json
- Update deno.lock to reflect new version
- Update flake.lock with latest dependencies

## Test plan
- [ ] CI checks pass (verify, scenario-test, scenario-test-nix)
- [ ] Ready to merge and trigger publish workflow