### PR TITLE
chore: bump version to 0.15.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/probitas",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "exports": {
     ".": "./src/mod.ts",
     "./cli": "./src/cli.ts",

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766870016,
-        "narHash": "sha256-fHmxAesa6XNqnIkcS6+nIHuEmgd/iZSP/VXxweiEuQw=",
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5c2bc52fb9f8c264ed6c93bd20afa2ff5e763dce",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Update version to 0.15.0 in deno.json
- Update deno.lock to reflect new version
- Update flake.lock with latest dependencies

## Test plan
- [ ] CI checks pass (verify, scenario-test, scenario-test-nix)
- [ ] Ready to merge and trigger publish workflow