### PR TITLE
chore: bump version to 0.21.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@probitas/probitas",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "exports": {
     ".": "./src/mod.ts",
     "./cli": "./src/cli.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -46,6 +46,8 @@
     "jsr:@probitas/core@~0.3.2": "0.3.2",
     "jsr:@probitas/discover@0.4": "0.4.0",
     "jsr:@probitas/expect@~0.4.1": "0.4.1",
+    "jsr:@probitas/probitas@*": "0.20.0",
+    "jsr:@probitas/probitas@0": "0.20.0",
     "jsr:@probitas/runner@~0.5.6": "0.5.6",
     "jsr:@std/assert@0.217": "0.217.0",
     "jsr:@std/assert@^1.0.14": "1.0.16",
@@ -312,6 +314,32 @@
         "jsr:@probitas/core@0",
         "jsr:@std/expect",
         "npm:diff"
+      ]
+    },
+    "@probitas/probitas@0.20.0": {
+      "integrity": "7e8a02f1a35d18da239fee53fec6afa9ee5c6f7fb1fc5b8182c23f1cd43313cf",
+      "dependencies": [
+        "jsr:@core/errorutil@^1.2.1",
+        "jsr:@cspotcode/outdent",
+        "jsr:@probitas/builder",
+        "jsr:@probitas/client-connectrpc@0.7",
+        "jsr:@probitas/client-deno-kv@0.5",
+        "jsr:@probitas/client-graphql@0.6",
+        "jsr:@probitas/client-grpc@0.6",
+        "jsr:@probitas/client-http@~0.7.2",
+        "jsr:@probitas/client-mongodb@0.6",
+        "jsr:@probitas/client-rabbitmq@0.5",
+        "jsr:@probitas/client-redis@0.5",
+        "jsr:@probitas/client-sql-duckdb",
+        "jsr:@probitas/client-sql-mysql",
+        "jsr:@probitas/client-sql-postgres",
+        "jsr:@probitas/client-sql-sqlite",
+        "jsr:@probitas/client-sql@0.5",
+        "jsr:@probitas/client-sqs@0.5",
+        "jsr:@probitas/expect",
+        "jsr:@probitas/runner",
+        "jsr:@std/testing",
+        "npm:@faker-js/faker"
       ]
     },
     "@probitas/runner@0.5.6": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769433173,
-        "narHash": "sha256-Gf1dFYgD344WZ3q0LPlRoWaNdNQq8kSBDLEWulRQSEs=",
+        "lastModified": 1769740369,
+        "narHash": "sha256-xKPyJoMoXfXpDM5DFDZDsi9PHArf2k5BJjvReYXoFpM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13b0f9e6ac78abbbb736c635d87845c4f4bee51b",
+        "rev": "6308c3b21396534d8aaeac46179c14c439a89b8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Update version to 0.21.0 in deno.json
- Update deno.lock to reflect new version
- Update flake.lock with latest dependencies

## Test plan
- [ ] CI checks pass (verify, scenario-test, scenario-test-nix)
- [ ] Ready to merge and trigger publish workflow